### PR TITLE
app_wsbrd: Write the request packet to pcapng file

### DIFF
--- a/app_wsbrd/commandline.c
+++ b/app_wsbrd/commandline.c
@@ -550,6 +550,7 @@ static void parse_config_line(struct wsbrd_conf *config, struct storage_parse_in
         { "lowpan_mtu",                    &config->lowpan_mtu,                       conf_set_number,      &valid_lowpan_mtu },
         { "pan_size",                      &config->pan_size,                         conf_set_number,      &valid_uint16 },
         { "pcap_file",                     config->pcap_file,                         conf_set_string,      (void *)sizeof(config->pcap_file) },
+        { "pcap_channel",                  &config->pcap_channel,                     conf_set_enum,        &valid_pcapng_channel },
     };
     int i;
 
@@ -641,6 +642,7 @@ void parse_commandline(struct wsbrd_conf *config, int argc, char *argv[],
     config->ws_regional_regulation = 0;
     config->ws_async_frag_duration = 500;
     config->pan_size = -1;
+    config->pcap_channel = PCAP_CHANNEL_RX | PCAP_CHANNEL_TX;
     strcpy(config->storage_prefix, "/var/lib/wsbrd/");
     memset(config->ws_allowed_channels, 0xFF, sizeof(config->ws_allowed_channels));
     while ((opt = getopt_long(argc, argv, opts_short, opts_long, NULL)) != -1) {

--- a/app_wsbrd/commandline.h
+++ b/app_wsbrd/commandline.h
@@ -22,6 +22,9 @@
 
 #include "stack/net_interface.h"
 
+#define PCAP_CHANNEL_RX                 (1 << 0)
+#define PCAP_CHANNEL_TX                 (1 << 1)
+
 // This struct is filled by parse_commandline() and never modified after.
 struct wsbrd_conf {
     bool list_rf_configs;
@@ -96,6 +99,7 @@ struct wsbrd_conf {
     int lowpan_mtu;
     int pan_size;
     char pcap_file[PATH_MAX];
+    int pcap_channel;
 };
 
 void print_help_br(FILE *stream);

--- a/app_wsbrd/commandline_values.c
+++ b/app_wsbrd/commandline_values.c
@@ -19,6 +19,7 @@
 #include "stack/source/6lowpan/ws/ws_common_defines.h"
 
 #include "commandline_values.h"
+#include "commandline.h"
 
 const struct name_value valid_ws_domains[] = {
     { "WW", REG_DOMAIN_WW }, // World wide
@@ -119,5 +120,12 @@ const struct name_value valid_booleans[] = {
 const struct name_value valid_ws_regional_regulations[] = {
     { "none", REG_REGIONAL_NONE },
     { "arib", REG_REGIONAL_ARIB },
+    { NULL },
+};
+
+const struct name_value valid_pcapng_channel[] = {
+    { "all",      PCAP_CHANNEL_RX | PCAP_CHANNEL_TX },
+    { "rx",       PCAP_CHANNEL_RX },
+    { "tx",       PCAP_CHANNEL_TX },
     { NULL },
 };

--- a/app_wsbrd/commandline_values.h
+++ b/app_wsbrd/commandline_values.h
@@ -23,5 +23,6 @@ extern const struct name_value valid_traces[];
 extern const struct name_value valid_booleans[];
 extern const struct name_value valid_tristate[];
 extern const struct name_value valid_ws_regional_regulations[];
+extern const struct name_value valid_pcapng_channel[];
 
 #endif

--- a/app_wsbrd/rcp_api.c
+++ b/app_wsbrd/rcp_api.c
@@ -944,8 +944,8 @@ static void rcp_rx_ind(struct wsbr_ctxt *ctxt, uint32_t prop, struct iobuf_read 
         req.PendingBit         = spinel_pop_bool(buf);
         req.PanIdSuppressed    = spinel_pop_bool(buf);
         // FIXME: remove this hack
-        if (ctxt->config.pcap_file[0])
-            wsbr_pcapng_write_frame(ctxt, &req, &ie_ext);
+        if (ctxt->config.pcap_file[0] && (ctxt->config.pcap_channel & PCAP_CHANNEL_RX))
+            wsbr_pcapng_write_ind_frame(ctxt, &req, &ie_ext);
     }
     if (!spinel_prop_is_valid(buf, prop))
         return;

--- a/app_wsbrd/wsbr.c
+++ b/app_wsbrd/wsbr.c
@@ -551,6 +551,7 @@ int wsbr_main(int argc, char *argv[])
         drop_privileges(&ctxt->config);
 
     wsbr_fds_init(ctxt, fds);
+    clock_gettime(CLOCK_MONOTONIC_RAW, &ctxt->boottime);
 
     while (true)
         wsbr_poll(ctxt, fds);

--- a/app_wsbrd/wsbr.h
+++ b/app_wsbrd/wsbr.h
@@ -51,6 +51,7 @@ struct wsbr_ctxt {
 
     int pcapng_fd;
     mode_t pcapng_type;
+    struct timespec boottime;
 
     struct {
         uint8_t eui64[8];

--- a/app_wsbrd/wsbr_mac.c
+++ b/app_wsbrd/wsbr_mac.c
@@ -112,6 +112,10 @@ void wsbr_data_req_ext(struct net_if *cur,
             // confirmation error.
             neighbor_ws = &neighbor_ws_dummy;
         }
+
+        if (g_ctxt.config.pcap_file[0] && (g_ctxt.config.pcap_channel & PCAP_CHANNEL_TX))
+            wsbr_pcapng_write_req_frame(&g_ctxt, cur->rcp, &cur->mac_parameters, data, ie_ext);
+
         wsbr_data_req_rebuild(&frame, cur->rcp, &cur->mac_parameters, data, ie_ext);
         rcp_tx_req(frame.data, frame.len, neighbor_ws, data->msduHandle,
                    data->fhss_type, data->ExtendedFrameExchange,

--- a/app_wsbrd/wsbr_pcapng.h
+++ b/app_wsbrd/wsbr_pcapng.h
@@ -5,7 +5,17 @@ struct wsbr_ctxt;
 struct mcps_data_ind;
 struct mcps_data_ie_list;
 
+struct rcp;
+struct arm_15_4_mac_parameters;
+struct mcps_data_req;
+struct mcps_data_req_ie_list;
+
 void wsbr_pcapng_init(struct wsbr_ctxt *ctxt);
-void wsbr_pcapng_write_frame(struct wsbr_ctxt *ctxt, struct mcps_data_ind *ind, struct mcps_data_ie_list *ie);
+void wsbr_pcapng_write_ind_frame(struct wsbr_ctxt *ctxt, struct mcps_data_ind *ind, struct mcps_data_ie_list *ie);
+void wsbr_pcapng_write_req_frame(struct wsbr_ctxt *ctxt,
+                                 const struct rcp *rcp,
+                                 const struct arm_15_4_mac_parameters *mac,
+                                 const struct mcps_data_req *req,
+                                 const struct mcps_data_req_ie_list *ie);
 
 #endif

--- a/examples/wsbrd.conf
+++ b/examples/wsbrd.conf
@@ -300,6 +300,8 @@ authority = examples/ca_cert.pem
 # Capture incoming Wi-SUN traffic in pcapng format. Use a FIFO to analyze
 # packets in real time using Wireshark. Acknowledgments are not captured
 # since they are processed at the RCP level.
+# Available pcap channels: rx, tx, all
+#pcap_channel = all
 #pcap_file = /tmp/dump.pcapng
 
 # Enable some debug traces. Same semantic than the -T option of wsbrd. This


### PR DESCRIPTION
Now the `wsbrd` can save both rx and tx packet to pcapng file. Next is a snapshot of wireshark after this patch:

![1695806657169](https://github.com/SiliconLabs/wisun-br-linux/assets/16350380/478eb76f-d139-4db5-9455-7787fc088295)
