### PR TITLE
legal: Fix SDPX Apache-2-0 license identifier

### DIFF
--- a/misc/com.silabs.Wisun.BorderRouter.service
+++ b/misc/com.silabs.Wisun.BorderRouter.service
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: GPL-2.0 or APACHE-2.0
+# SPDX-License-Identifier: GPL-2.0 or Apache-2.0
 
 [D-BUS Service]
 Name=com.silabs.Wisun.BorderRouter

--- a/misc/wisun-borderrouter.service
+++ b/misc/wisun-borderrouter.service
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: GPL-2.0 or APACHE-2.0
+# SPDX-License-Identifier: GPL-2.0 or Apache-2.0
 [Unit]
 Description=Wi-SUN Border Router Service
 Documentation=file:///usr/local/share/doc/wsbrd/examples/wsbrd.conf


### PR DESCRIPTION
This was observed using reuse tool:

* Bad licenses: APACHE-2.0

Origin: https://github.com/SiliconLabs/wisun-br-linux/pulls?q=author%3Arzr