### PR TITLE
str_eui48: Fix bounds issue on "out" variable.

### DIFF
--- a/common/log.c
+++ b/common/log.c
@@ -110,7 +110,7 @@ char *str_key(const uint8_t *in, int in_len, char *out, int out_len)
 
 char *str_eui48(const uint8_t in[6], char out[STR_MAX_LEN_EUI48])
 {
-    return str_bytes(in, 6, NULL, out, STR_MAX_LEN_EUI64, DELIM_COLON);
+    return str_bytes(in, 6, NULL, out, STR_MAX_LEN_EUI48, DELIM_COLON);
 }
 
 char *str_eui64(const uint8_t in[8], char out[STR_MAX_LEN_EUI64])


### PR DESCRIPTION
The max size for "out" when given to str_bytes() is given as a STR_MAX_LEN_EUI64, but it really should be STR_MAX_LEN_EUI48