### PR TITLE
Allowing compiling without DBUS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,6 @@ add_library(libwsbrd STATIC
     common/bus_uart.c
     common/capture.c
     common/commandline.c
-    common/dbus.c
     common/events_scheduler.c
     common/log.c
     common/bits.c
@@ -270,7 +269,7 @@ if(LIBCAP_FOUND)
 endif()
 if(LIBSYSTEMD_FOUND)
     target_compile_definitions(libwsbrd PRIVATE HAVE_LIBSYSTEMD)
-    target_sources(libwsbrd PRIVATE app_wsbrd/app/dbus.c)
+    target_sources(libwsbrd PRIVATE common/dbus.c app_wsbrd/app/dbus.c)
     if(AUTH_LEGACY)
         target_sources(libwsbrd PRIVATE app_wsbrd/app/dbus_auth_legacy.c)
     else()

--- a/app_wsbrd/app/dbus.h
+++ b/app_wsbrd/app/dbus.h
@@ -21,7 +21,7 @@ struct wsbr_ctxt;
 
 extern const struct sd_bus_vtable wsbrd_dbus_vtable[];
 #else
-static const struct sd_bus_vtable *wsbrd_dbus_vtable;
+static const struct sd_bus_vtable *const wsbrd_dbus_vtable;
 #endif
 
 #endif


### PR DESCRIPTION
There is a minor bug in CMakeLists.txt that always brings in common/dbus.c, even though later in the CMakeLists.txt file it is properly bounded by the check of "if(LIBSYSTEMD_FOUND)" (See line ~373 in CMakeLists.txt for it)

Because the line always brings in common/dbus.c, building without dbus isn't possible.
Removing the 1 line from the CMakeLists.txt fixes this issue.
