### PR TITLE
Fix compile issue with missing/needed <endian.h> includes

### DIFF
--- a/common/crypto/ieee80211.c
+++ b/common/crypto/ieee80211.c
@@ -17,6 +17,7 @@
  */
 #include <string.h>
 #include <stdint.h>
+#include <endian.h>
 #include <mbedtls/md.h>
 #include "common/specs/ieee80211.h"
 #include "common/specs/eapol.h"

--- a/common/ieee802154_frame.c
+++ b/common/ieee802154_frame.c
@@ -12,6 +12,7 @@
  * [1]: https://www.silabs.com/about-us/legal/master-software-license-agreement
  */
 #include <errno.h>
+#include <endian.h>
 
 #include "common/bits.h"
 #include "common/endian.h"


### PR DESCRIPTION
Without adding in the include of <endian.h> in 2 files that use functions/defines from it, we end up getting compiler errors and linking errors.
(Specifically, the htobe16 and be64toh functions/defines, which exist in <endian.h>)

Including the compile log below, just to show the errors that we get:

`
[22/132] Building C object CMakeFiles/libwsbrd.dir/common/crypto/ieee80211.c.o
common/crypto/ieee80211.c: In function ‘ieee80211_is_mic_valid’:
common/crypto/ieee80211.c:39:31: warning: implicit declaration of function ‘htobe16’ [-Wimplicit-function-declaration]
   39 |         .packet_body_length = htobe16(sizeof(*frame) + data_len),
      |                               ^~~~~~~
[57/132] Building C object CMakeFiles/libwsbrd.dir/common/ieee802154_frame.c.o
common/ieee802154_frame.c: In function ‘ieee802154_frame_parse’:
common/ieee802154_frame.c:204:25: warning: implicit declaration of function ‘htobe64’ [-Wimplicit-function-declaration]
  204 |         hdr->dst.be64 = htobe64(iobuf_pop_le64(&iobuf));
      |                         ^~~~~~~
common/ieee802154_frame.c: In function ‘ieee802154_frame_write_hdr’:
common/ieee802154_frame.c:274:32: warning: implicit declaration of function ‘be64toh’ [-Wimplicit-function-declaration]
  274 |         iobuf_push_le64(iobuf, be64toh(hdr->dst.be64));
      |                                ^~~~~~~
[131/132] Linking C executable wsbrd
`


