### PR TITLE
conf: fix support for private key PEM files other than PKCS#8

### DIFF
--- a/common/commandline.c
+++ b/common/commandline.c
@@ -303,7 +303,8 @@ void conf_set_pem(const struct storage_parse_info *info, void *raw_dest, const v
               ret < 0 ? strerror(errno) : "Short read");
     dest->iov_len = ret;
     if (strstr(dest_str, "-----BEGIN CERTIFICATE-----") ||
-        strstr(dest_str, "-----BEGIN PRIVATE KEY-----"))
+        strstr(dest_str, "-----BEGIN PRIVATE KEY-----") ||
+        strstr(dest_str, "-----BEGIN EC PRIVATE KEY-----"))
         dest->iov_len++;
     close(fd);
 }


### PR DESCRIPTION
The Mbed TLS bug being worked around
(https://github.com/Mbed-TLS/mbedtls/issues/3896)
affects _all_ PEM inputs.
`conf_set_pem` only applied the workaround to certificates and PKCS#8 encoded keys.