### PR TITLE
common/authenticator: Fix compiler issues with missing endian.h include

### DIFF
--- a/common/authenticator/authenticator.c
+++ b/common/authenticator/authenticator.c
@@ -17,6 +17,7 @@
 #include <inttypes.h>
 #include <errno.h>
 #include <string.h>
+#include <endian.h>
 
 #include "common/specs/ieee802159.h"
 #include "common/specs/ieee80211.h"

--- a/common/authenticator/authenticator_eap.c
+++ b/common/authenticator/authenticator_eap.c
@@ -11,6 +11,7 @@
  *
  * [1]: https://www.silabs.com/about-us/legal/master-software-license-agreement
  */
+#include <endian.h>
 #include "common/authenticator/authenticator.h"
 #include "common/authenticator/authenticator_radius.h"
 #include "common/authenticator/authenticator_key.h"


### PR DESCRIPTION
This commit brings in 2 missing endian.h includes to support the be16toh() call

Without this patch, the following compiler errors occur:

```
In file included from ./common/memutils.h:17,
                 from common/authenticator/authenticator.c:31:
common/authenticator/authenticator.c: In function ‘auth_send_eapol’: common/authenticator/authenticator.c:447:68: warning: implicit declaration of function ‘be16toh’ [-Wimplicit-function-declaration]
  447 |               val_to_str(hdr->packet_type, eapol_frames, "[UNK]"), be16toh(hdr->packet_body_length));
      |                                                                    ^~~~~~~

common/authenticator/authenticator_eap.c: In function ‘auth_eap_recv’: common/authenticator/authenticator_eap.c:325:9: warning: implicit declaration of function ‘be16toh’ [-Wimplicit-function-declaration]
  325 |     if (be16toh(eap->length) > buf_len) {
      |         ^~~~~~~
```

Per man endian(3), the be16toh() #define is in <endian.h>